### PR TITLE
Unify request sending with httpx

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -6,7 +6,6 @@ import random
 import asyncio
 import logging
 import base64
-import requests
 import httpx
 import urllib3
 import zoneinfo
@@ -63,7 +62,7 @@ def get_country_by_ip(ip: str) -> str:
     if ip in geo_cache:
         return geo_cache[ip]
     try:
-        r = requests.get(f"https://ipwhois.app/json/{ip}", timeout=5)
+        r = httpx.get(f"https://ipwhois.app/json/{ip}", timeout=5)
         if r.status_code == 200:
             code = r.json().get("country_code", "unknown").lower()
             geo_cache[ip] = code
@@ -73,11 +72,11 @@ def get_country_by_ip(ip: str) -> str:
     geo_cache[ip] = "unknown"
     return "unknown"
 
-# ──────────────── Fetch & Decode ────────────────
-def fetch_data(url: str, timeout: int = 10) -> str:
+# ──────────────── Request Helper ────────────────
+def send_request(url: str, timeout: int = 10) -> str:
     headers = {"User-Agent": CHROME_UA}
     try:
-        resp = requests.get(url, headers=headers, timeout=timeout, verify=False)
+        resp = httpx.get(url, headers=headers, timeout=timeout, verify=False)
         resp.raise_for_status()
         return resp.text
     except Exception as e:
@@ -300,7 +299,7 @@ async def main_async():
 
         # Fetch & categorize
         for url in URLS:
-            blob = maybe_base64_decode(fetch_data(url))
+            blob = maybe_base64_decode(send_request(url))
             configs = re.findall(r"[a-zA-Z][\w+.-]*://[^\s]+", blob)
             logging.info(f"Fetched {url} → {len(configs)} configs")
 

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,4 +1,3 @@
 aiofiles>=23.1.0
-requests>=2.28.0
 httpx>=0.24.0
 urllib3>=1.26.0


### PR DESCRIPTION
## Summary
- replace `requests` usage with `httpx`
- add `send_request` helper for fetching configs
- drop `requests` dependency

## Testing
- `pip install -r source/requirements.txt`
- `python -m py_compile source/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58e36959c8331bfa4a220a08f41d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified network request handling through a single helper, standardizing headers, timeouts, and error handling across the app. Call sites updated for consistency. No changes expected to user-visible behavior or results.
* **Chores**
  * Removed an unused HTTP client dependency from installation requirements to streamline the package footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->